### PR TITLE
Update prepared statements capability

### DIFF
--- a/databases/mysqli-or-pdo.md
+++ b/databases/mysqli-or-pdo.md
@@ -15,7 +15,7 @@ Feature | PDO | MySQLi
 **Interface** | OOP | OOP and procedural
 **Named parameters** | Yes | No
 **Object mapping** | Yes | Yes
-**Prepared statements (client side)** | Yes | No
+**Prepared statements** | Yes | Yes
 **Non-blocking, asynchronous queries with mysqlnd support** | No | Yes
 **Multiple Statements support** | Most | Yes
 **MySQL 5.1+ functionality support** | Most | All


### PR DESCRIPTION
The word 'client-side prepared statements' is a feature of PDO which will emulate prepared statements when the specific driver does not support. Because MySQL had supported prepared statements since version 4.1, PDO does not have to emulate them at all. So it's better not to tell reader about this, it can cause confusion (I saw a post in the fb group which a user thought mysqli does not support prepared statements).