### PR TITLE
Removed a sentence

### DIFF
--- a/security/cryptography.md
+++ b/security/cryptography.md
@@ -9,9 +9,8 @@ professionals only.
 key.
 
 **Hashing** changes data in a way that it cannot be converted back to the original.
-Strong hashing algorithms are practically impossible to turn the hash back to
-the original data. Hashing is commonly used for storing passwords. Application
-doesn't need to know the plain password to operate successfully.
+Hashing is commonly used for storing passwords. Application doesn't need to know
+the plain password to operate successfully.
 
 **Encoding** is explained here only for better overview. It has nothing to do with
 the cryptographic algorithms directly. Encoding is transforming data so that they


### PR DESCRIPTION
I think the sentence `Strong hashing algorithms are practically impossible to turn the hash back to the original data. `
can lead to confusion (especially the phrase `turn the hash back`). Because your goal is to make readers understand that hashing is one-way data mapping.
If you want to talk about strength of algorithms, instead you can explain more about hash collisions. ✌️ 